### PR TITLE
Added Timeout::Error as the default error class to allow for rescue_from Timeout::Error in Rails

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,11 @@
 Rack::Timeout
 =============
 
-Abort requests that are taking too long.
+Abort requests with Timeout::Error when they are taking too long.
+
+This fork differs from kch's in that it adds Timeout::Error as the default error class when calling timeout.
+Passing in the error class allows Rails to use rescue_from Timeout::Error in Rails controllers instead of
+rescue_from Exception.
 
 
 Usage

--- a/lib/rack/timeout.rb
+++ b/lib/rack/timeout.rb
@@ -13,7 +13,7 @@ module Rack
     end
 
     def call(env)
-      SystemTimer.timeout(self.class.timeout) { @app.call(env) }
+      SystemTimer.timeout(self.class.timeout, ::Timeout::Error) { @app.call(env) }
     end
 
   end


### PR DESCRIPTION
In current implementation without passing in error class, rescue_from Timeout::Error in Rails 3 doesn't work since rescue_from ends up receiving ExitError instead of Timeout::Error.

Passing in Timeout::Error to Timeout.timeout fixes the problem.
