### PR TITLE
cast request_start to float instead of integer

### DIFF
--- a/lib/rack/timeout.rb
+++ b/lib/rack/timeout.rb
@@ -28,7 +28,7 @@ module Rack
       info          = env[ENV_INFO_KEY] ||= RequestDetails.new
       info.id     ||= env['HTTP_HEROKU_REQUEST_ID'] || SecureRandom.hex
       request_start = env['HTTP_X_REQUEST_START'] # unix timestamp in ms
-      request_start = Time.at(request_start.to_i / 1000) if request_start
+      request_start = Time.at(request_start.to_f / 1000) if request_start
       info.age      = Time.now - request_start           if request_start
       time_left     = MAX_REQUEST_AGE - info.age         if info.age
       info.timeout  = [self.class.timeout, time_left].compact.select { |n| n >= 0 }.min


### PR DESCRIPTION
Dividing by 1000 resulted in loss of precision, resulting in a truncation error.

Fixes #23.
