### PR TITLE
Added support for nginx proxy_set_header X-Request-Start $msec and t=${msec}

### DIFF
--- a/lib/rack/timeout.rb
+++ b/lib/rack/timeout.rb
@@ -25,7 +25,7 @@ module Rack
       info          = env[ENV_INFO_KEY] ||= RequestDetails.new
       info.id     ||= env['HTTP_HEROKU_REQUEST_ID'] || env['HTTP_X_REQUEST_ID'] || SecureRandom.hex
       request_start = env['HTTP_X_REQUEST_START'] # unix timestamp in ms
-      request_start = Time.at(request_start.to_f / 1000) if request_start
+      request_start = Time.at(request_start.tr('^0-9', '').to_f / 1000) if request_start
       info.age      = Time.now - request_start           if request_start
       time_left     = MAX_REQUEST_AGE - info.age         if info.age
       time_left    += self.class.overtime                if time_left && self.class._request_has_body?(env)


### PR DESCRIPTION
Thanks for the awesome gem!  This commit makes it easier to configure `X-Request-Start` for Nginx.  It adds support for the following configurations:

``` conf
proxy_set_header X-Request-Start $msec;
```

and

``` conf
proxy_set_header X-Request-Start "t=${msec}";
```
