### PR TITLE
Update the gemspec's homepage to the current repo URL

### DIFF
--- a/rack-timeout.gemspec
+++ b/rack-timeout.gemspec
@@ -5,16 +5,16 @@ Gem::Specification.new do |spec|
   spec.summary     = "Abort requests that are taking too long"
   spec.description = "Rack middleware which aborts requests that have been running for longer than a specified timeout."
   spec.version     = RACK_TIMEOUT_VERSION
-  spec.homepage    = "https://github.com/sharpstone/rack-timeout"
+  spec.homepage    = "https://github.com/zombocom/rack-timeout"
   spec.author      = "Caio Chassot"
   spec.email       = "caio@heroku.com"
   spec.files       = Dir[*%w( MIT-LICENSE CHANGELOG.md UPGRADING.md README.md lib/**/* doc/**/* )]
   spec.license     = "MIT"
   spec.metadata = {
-    "bug_tracker_uri"   => "https://github.com/sharpstone/rack-timeout/issues",
-    "changelog_uri"     => "https://github.com/sharpstone/rack-timeout/blob/v#{RACK_TIMEOUT_VERSION}/CHANGELOG.md",
+    "bug_tracker_uri"   => "#{spec.homepage}/issues",
+    "changelog_uri"     => "#{spec.homepage}/blob/v#{RACK_TIMEOUT_VERSION}/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/gems/rack-timeout/#{RACK_TIMEOUT_VERSION}/",
-    "source_code_uri"   => "https://github.com/sharpstone/rack-timeout"
+    "source_code_uri"   => spec.homepage
 }
 
   spec.test_files = Dir.glob("test/**/*").concat([


### PR DESCRIPTION
This reduces unnecessary redirection when someone visits this gem's homepage via https://rubygems.org/gems/rack-timeout or some tools or APIs that use the gem's metadata.