### PR TITLE
Add upper bound to compatible Rails versions

### DIFF
--- a/lib/rack-timeout.rb
+++ b/lib/rack-timeout.rb
@@ -1,2 +1,2 @@
 require_relative "rack/timeout/base"
-require_relative "rack/timeout/rails" if defined?(Rails) && Rails::VERSION::MAJOR >= 3
+require_relative "rack/timeout/rails" if defined?(Rails) && [3,4,5,6,7].include?(Rails::VERSION::MAJOR)


### PR DESCRIPTION
`Rails::VERSION::MAJOR >= 3` implies this is a future proof gem that will work with `rails ~>12.3.4` whenever it is released in the future. This proposed change errors on the side of caution to better outline which known major versions of `rails` are known to be compatible with this specific version of this gem.