### PR TITLE
Rails no const VERSION (followup #180)

### DIFF
--- a/lib/rack-timeout.rb
+++ b/lib/rack-timeout.rb
@@ -1,2 +1,2 @@
 require_relative "rack/timeout/base"
-require_relative "rack/timeout/rails" if defined?(Rails) && Rails::VERSION::MAJOR >= 3
+require_relative "rack/timeout/rails" if defined?(Rails) && Rails.const_defined?(:VERSION) && Rails::VERSION::MAJOR >= 3


### PR DESCRIPTION
followup #180

```
dev >> Rails
NameError: uninitialized constant Rails
from (pry):3:in `__pry__'
dev >> require 'web-console'
=> true
dev >> Rails
=> Rails
dev >> Rails::VERSION
NameError: uninitialized constant Rails::VERSION
Did you mean?  Version
from (pry):8:in `__pry__'
dev >> Rails.const_defined?(:VERSION)
=> false
dev >> Rails::VERSION = "3.3.3"
=> "3.3.3"
dev >> Rails.const_defined?(:VERSION)
=> true
```