### PR TITLE
Add tests and improve error messages on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         ruby:
           - '2.2'
           - '2.3'
@@ -20,6 +20,7 @@ jobs:
           - '3.0'
           - '3.1'
           - 'head'
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## HEAD (unreleased)
+ - Improve message when Terminate on Timeout is used on a platform that does not support it (eg. Windows or JVM)
 
 ## 0.6.3
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -74,8 +74,15 @@ module Rack
       @service_past_wait = service_past_wait == "not_specified" ? ENV.fetch("RACK_TIMEOUT_SERVICE_PAST_WAIT", false).to_s != "false" : service_past_wait
 
       Thread.main['RACK_TIMEOUT_COUNT'] ||= 0
-      if @term_on_timeout
-        raise "Current Runtime does not support processes" unless ::Process.respond_to?(:fork)
+      if @term_on_timeout && !::Process.respond_to?(:fork)
+        raise(NotImplementedError, <<-MSG)
+Current Runtime does not support processes. 
+This probably means that the platform is Windows.
+
+To avoid this error, either specify RACK_TIMEOUT_TERM_ON_TIMEOUT=0 or 
+leave it as default (which will have the same result).
+
+MSG
       end
       @app = app
     end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -76,8 +76,7 @@ module Rack
       Thread.main['RACK_TIMEOUT_COUNT'] ||= 0
       if @term_on_timeout && !::Process.respond_to?(:fork)
         raise(NotImplementedError, <<-MSG)
-Current Runtime does not support processes. 
-This probably means that the platform is Windows.
+The platform running your application does not support forking (i.e. Windows, JVM, etc).
 
 To avoid this error, either specify RACK_TIMEOUT_TERM_ON_TIMEOUT=0 or 
 leave it as default (which will have the same result).

--- a/test/env_settings_test.rb
+++ b/test/env_settings_test.rb
@@ -2,13 +2,6 @@ require 'test_helper'
 
 class EnvSettingsTest < RackTimeoutTest
 
-  def test_service_timeout
-    with_env(RACK_TIMEOUT_SERVICE_TIMEOUT: 1) do
-      assert_raises(Rack::Timeout::RequestTimeoutError) do
-        get "/sleep"
-      end
-    end
-  end
 
   def test_zero_wait_timeout
     with_env(RACK_TIMEOUT_WAIT_TIMEOUT: 0) do
@@ -17,10 +10,21 @@ class EnvSettingsTest < RackTimeoutTest
     end
   end
 
-  def test_term
-    with_env(RACK_TIMEOUT_TERM_ON_TIMEOUT: 1) do
-      assert_raises(SignalException) do
-        get "/sleep"
+  
+  if Process.respond_to?(:fork) # This functionality does not work on windows, so we cannot test it there.
+    def test_service_timeout
+      with_env(RACK_TIMEOUT_SERVICE_TIMEOUT: 1) do
+        assert_raises(Rack::Timeout::RequestTimeoutError) do
+          get "/sleep"
+        end
+      end
+    end
+
+    def test_term
+      with_env(RACK_TIMEOUT_TERM_ON_TIMEOUT: 1) do
+        assert_raises(SignalException) do
+          get "/sleep"
+        end
       end
     end
   end

--- a/test/env_settings_test.rb
+++ b/test/env_settings_test.rb
@@ -27,5 +27,13 @@ class EnvSettingsTest < RackTimeoutTest
         end
       end
     end
+  else
+    def test_service_timeout # Confirm that on Windows we raise an exception when someone attempts to use term on timeout
+      with_env(RACK_TIMEOUT_TERM_ON_TIMEOUT: 1) do 
+        assert_raises(NotImplementedError) do
+          get "/"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add Windows to the testing matrix, and exclude tests on Windows for Terminate on Timeout which is not supported on the platform.

Since Windows is a bit more supported now, add a more informative message for the exception.

Fixes #179 