### PR TITLE
Remove unnecessary executable permission bit from Ruby file

### DIFF
--- a/lib/rack/timeout/support/scheduler.rb
+++ b/lib/rack/timeout/support/scheduler.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 require_relative "namespace"
 require_relative "monotonic_time"
 


### PR DESCRIPTION
The file is not executed directly, so remove the permission bit.