### PR TITLE
ensure mutated strings are mutable

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -133,7 +133,7 @@ MSG
       timeout = RT::Scheduler::Timeout.new do |app_thread|  # creates a timeout instance responsible for timing out the request. the given block runs if timed out
         register_state_change.call :timed_out
 
-        message = "Request "
+        message = +"Request "
         message << "waited #{info.ms(:wait)}, then " if info.wait
         message << "ran for longer than #{info.ms(:timeout)} "
         if term_on_timeout

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -43,7 +43,7 @@ class Rack::Timeout::StateChangeLoggingObserver
     info = env[::Rack::Timeout::ENV_INFO_KEY]
     level = STATE_LOG_LEVEL[info.state]
     logger(env).send(level) do
-      s  = "source=rack-timeout"
+      s  = +"source=rack-timeout"
       s << " id="      << info.id           if info.id
       s << " wait="    << info.ms(:wait)    if info.wait
       s << " timeout=" << info.ms(:timeout) if info.timeout


### PR DESCRIPTION
Hello, thank you for the incredibly useful library!

I was experimenting with freezing strings in my application by default with `RUBYOPT=--enable=frozen-string-literal`, and `rack-timeout` has a couple places I ran into that are preventing it.

I opted for a minimal changeset as I wasn't sure if there would be openness to freezing strings within the library itself with `# frozen_string_literal: true` (but I'd be happy to include that here too if you'd like).

Error messages I received in testing:
```
can't modify frozen String: "source=rack-timeout" (FrozenError)
can't modify frozen String: "Request " (FrozenError)
```