### PR TITLE
Add Ruby 3.2 to CI and test Rack 2/3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
+        rack-version: ['~> 2.0', '~> 3.0']
         ruby:
           - '2.2'
           - '2.3'
@@ -19,8 +20,16 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
           - 'head'
+        exclude:
+          - ruby: '2.2'
+            rack-version: '~> 3.0'
+          - ruby: '2.3'
+            rack-version: '~> 3.0'
     runs-on: ${{ matrix.os }}
+    env:
+      RACK_VERSION: ${{ matrix.rack-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rack', ENV['RACK_VERSION'] if ENV['RACK_VERSION']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require "test/unit"
+require "rack"
 require "rack/test"
 require "rack-timeout"
 


### PR DESCRIPTION
This PR adds Ruby 3.2 to the CI matrix.

My original runs failed, because it is necessary to explicitly require `rack` in the `test_helper.rb` when using Rack 3.x.  Since Rack 2.x is still the standard Rack for Rails, and is likely going to be around for a while, I expanded the CI matrix to test against 2.x and 3.x individually.

Everything runs green on my fork.