### PR TITLE
add requires to get tests passing with recent library versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ This version of Rack::Timeout is compatible with Ruby 2.1 and up, and,
 for Rails apps, Rails 3.x and up.
 
 
+Contributing
+------------
+
+Run the test suite:
+
+```console
+bundle
+bundle exec rake test
+```
+
 ---
 Copyright © 2010-2020 Caio Chassot, released under the MIT license
 <http://github.com/sharpstone/rack-timeout>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 require "test/unit"
 require "rack/test"
+require "rack/builder"
+require "rack/null_logger"
 require "rack-timeout"
 
 class RackTimeoutTest < Test::Unit::TestCase


### PR DESCRIPTION
ruby 3.2

bundler 2.4

    power_assert (2.0.3)
    rack (3.0.8)
    rack-test (2.1.0)
      rack (>= 1.3)
    rake (13.0.6)
    test-unit (3.6.1)
      power_assert
