### PR TITLE
Honor Apache X-Request-Start header containing microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (unreleased)
  - Improve message when Terminate on Timeout is used on a platform that does not support it (eg. Windows or JVM)
- - Honor an `X-Request-Start` header with Apache's standard `t=<microseconds>` format, to allow using `wait_timeout` functionality
+ - Honor an `X-Request-Start` header with the `t=<microseconds>` format, to allow using `wait_timeout` functionality with Apache
 
 ## 0.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
  - Improve message when Terminate on Timeout is used on a platform that does not support it (eg. Windows or JVM)
+ - Honor an `X-Request-Start` header with Apache's standard `t=<microseconds>` format, to allow using `wait_timeout` functionality
 
 ## 0.6.3
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,19 @@
 Upgrading
 =========
 
+From 0.6.3 or older
+-----------------
+
+- Apache's `X-Request-Start` header is now recognized, which if present
+  will trigger the default `wait_timeout` behavior (unless you have changed
+  those settings or disabled it).
+
+  Please review `wait_timeout` behavior in [doc/settings.md](doc/settings.md#wait-timeout).
+
+  TL;DR -> set `wait_timeout` to `0` or `'false'` to disable it and maintain
+  your Apache setup's current behavior.
+
+
 From 0.4 or older
 -----------------
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,19 +1,6 @@
 Upgrading
 =========
 
-From 0.6.3 or older
------------------
-
-- Apache's `X-Request-Start` header is now recognized, which if present
-  will trigger the default `wait_timeout` behavior (unless you have changed
-  those settings or disabled it).
-
-  Please review `wait_timeout` behavior in [doc/settings.md](doc/settings.md#wait-timeout).
-
-  TL;DR -> set `wait_timeout` to `0` or `'false'` to disable it and maintain
-  your Apache setup's current behavior.
-
-
 From 0.4 or older
 -----------------
 

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -29,9 +29,18 @@ Wait timeout can be disabled entirely by setting the property to `0` or `false`.
 
 A request's computed wait time may affect the service timeout used for it. Basically, a request's wait time plus service time may not exceed the wait timeout. The reasoning for that is based on Heroku router's behavior, that the request would be dropped anyway after the wait timeout. So, for example, with the default settings of `service_timeout=15`, `wait_timeout=30`, a request that had 20 seconds of wait time will not have a service timeout of 15, but instead of 10, as there are only 10 seconds left before `wait_timeout` is reached. This behavior can be disabled by setting `service_past_wait` to `true`. When set, the `service_timeout` setting will always be honored. Please note that if you're using the `RACK_TIMEOUT_SERVICE_PAST_WAIT` environment variable, any value different than `"false"` will be considered `true`.
 
-The way we're able to infer a request's start time, and from that its wait time, is through the availability of the `X-Request-Start` HTTP header, which is expected to contain the time since epoch in milliseconds. (A concession is made for nginx's sec.msec notation.)
+The way we're able to infer a request's start time, and from that its wait time, is through the availability of the `X-Request-Start` HTTP header, which is expected to contain the time since UNIX epoch in milliseconds or microseconds.
 
-If the `X-Request-Start` header is not present `wait_timeout` handling is skipped entirely.
+Compatible header string formats are:
+
+- `seconds.milliseconds`, e.g. `1700173924.763` - 10.3 digits, nginx standard format
+- `t=seconds.milliseconds`, e.g. `t=1700173924.763` - 10.3 digits, nginx standard format with [New Relic recommended][new-relic-recommended-format] `t=` prefix
+- `milliseconds`, e.g. `1700173924763` - 13 digits, Heroku standard format
+- `t=microseconds`, e.g. `t=1700173924763384` - 16 digits with `t=` prefix, Apache standard format
+
+[new-relic-recommended-format]: https://docs.newrelic.com/docs/apm/applications-menu/features/request-queue-server-configuration-examples/
+
+If the `X-Request-Start` header is not present, or does not match one of these formats, `wait_timeout` handling is skipped entirely.
 
 ### Wait Overtime
 

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -20,4 +20,11 @@ class BasicTest < RackTimeoutTest
       get "/", "", 'HTTP_X_REQUEST_START' => time_in_msec(Time.now - 100)
     end
   end
+
+  def test_apache_formatted_header_wait_timeout
+    self.settings = { service_timeout: 1, wait_timeout: 15 }
+    assert_raises(Rack::Timeout::RequestExpiryError) do
+      get "/", "", 'HTTP_X_REQUEST_START' => "t=#{time_in_usec(Time.now - 100)}"
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 require "test/unit"
 require "rack/test"
+require "rack/builder"
+require "rack/null_logger"
 require "rack-timeout"
 
 class RackTimeoutTest < Test::Unit::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,6 @@ class RackTimeoutTest < Test::Unit::TestCase
 
   def time_in_usec(t = Time.now)
     # time in microseconds, currently 16 digits
-    "#{t.tv_sec}#{t.tv_usec}"
+    "%d%06d" % [t.tv_sec, t.tv_usec]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,4 +44,9 @@ class RackTimeoutTest < Test::Unit::TestCase
   def time_in_msec(t = Time.now)
     "#{t.tv_sec}#{t.tv_usec/1000}"
   end
+
+  def time_in_usec(t = Time.now)
+    # time in microseconds, currently 16 digits
+    "#{t.tv_sec}#{t.tv_usec}"
+  end
 end


### PR DESCRIPTION
At my work we recently switched to nginx from Apache, and were puzzled why we began seeing errors to do with rack-timeout's wait_timeout behavior when we hadn't before.  We'd had the X-Request-Start header set on Apache for some time (years)

I tracked it down to the Apache-formatted header with microseconds, e.g. "t=" + 16 digits like `t=1700173924763384`, not being honored, [as mentioned here](https://github.com/zombocom/rack-timeout/blob/0f35a85a89a8206c2b8a2d1714c39329b3490ce6/lib/rack/timeout/core.rb#L172).

This PR adds that capability, with a test, and also adds notes to docs/settings.md,  UPGRADING.md, and CHANGELOG.md

First commit contains two lines I needed to add to be able to run the project's tests with `rake`. 