### PR TITLE
needed to make this safe for forks from non-main threads

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -73,7 +73,6 @@ module Rack
       @wait_overtime     = read_timeout_property wait_overtime,   ENV.fetch("RACK_TIMEOUT_WAIT_OVERTIME", 60).to_i
       @service_past_wait = service_past_wait == "not_specified" ? ENV.fetch("RACK_TIMEOUT_SERVICE_PAST_WAIT", false).to_s != "false" : service_past_wait
 
-      Thread.main['RACK_TIMEOUT_COUNT'] ||= 0
       if @term_on_timeout && !::Process.respond_to?(:fork)
         raise(NotImplementedError, <<-MSG)
 The platform running your application does not support forking (i.e. Windows, JVM, etc).
@@ -137,6 +136,7 @@ MSG
         message << "waited #{info.ms(:wait)}, then " if info.wait
         message << "ran for longer than #{info.ms(:timeout)} "
         if term_on_timeout
+          Thread.main['RACK_TIMEOUT_COUNT'] ||= 0
           Thread.main['RACK_TIMEOUT_COUNT'] += 1
 
           if Thread.main['RACK_TIMEOUT_COUNT'] >= @term_on_timeout

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require "test/unit"
+require "rack"
 require "rack/test"
 require "rack-timeout"
 


### PR DESCRIPTION
If a process happens to fork from a non-main thread (as happens e.g. in Puma's `fork_worker` mode) the term_on_timeout counter effectively disappears; whichever thread calls `.fork` becomes `Thread.main` in the child process, losing the parent's `Thread.main` storage. There are a few alternative solutions available: make this a real global (makes people feel icky but that's really what the code is doing) or adding a `_fork` hook (only practical on recent Rubies or with ActiveSupport required), but the simplest method is to move the `||= 0` initialization code prior to the request-time code that expects it.

Happy to put up a PR with the alternate methods if you'd prefer, please lmk.

(the `test_helper` change is required for tests to work at all on my local; lots of failures for undefined Rack::Builder otherwise)