### PR TITLE
Remove unused exclude for ruby 2.2 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - '3.2'
           - 'head'
         exclude:
-          - ruby: '2.2'
-            rack-version: '~> 3.0'
           - ruby: '2.3'
             rack-version: '~> 3.0'
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ bundle exec rake test
 Compatibility
 -------------
 
-This version of Rack::Timeout is compatible with Ruby 2.1 and up, and,
+This version of Rack::Timeout is compatible with Ruby 2.3 and up, and,
 for Rails apps, Rails 3.x and up.
 
 


### PR DESCRIPTION
Ruby 2.2 support was removed in https://github.com/zombocom/rack-timeout/commit/30e3f6fc566bc90204154605bf8011b63823d752